### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,10 +1,10 @@
-MSP  KEYWORD1
+MSP	KEYWORD1
 
-begin KEYWORD2
-send KEYWORD2
-recv KEYWORD2
-waitFor  KEYWORD2
-request  KEYWORD2
-command KEYWORD2
-getActiveModes KEYWORD2
+begin	KEYWORD2
+send	KEYWORD2
+recv	KEYWORD2
+waitFor	KEYWORD2
+request	KEYWORD2
+command	KEYWORD2
+getActiveModes	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords